### PR TITLE
Fix reading messages from client Sockets

### DIFF
--- a/src/main/java/com/github/jtmsp/socket/TSocket.java
+++ b/src/main/java/com/github/jtmsp/socket/TSocket.java
@@ -117,6 +117,10 @@ public class TSocket {
                     // To facilitate reading an exact number of bytes we use a CodedInputStream.
                     // BufferedInputStream.read would still need to be called in a loop, to ensure that all data is received.
 
+                    // Size counter is used to enforce a size limit per message (see CodedInputStream.setSizeLimit()).
+                    // We need to reset it before reading the next message:
+                    inputStream.resetSizeCounter();
+
                     // HEADER: first byte is length of length field
                     byte varintLength = inputStream.readRawByte();
                     if (varintLength > 4) {


### PR DESCRIPTION
[`BufferedInputStream.read()`](https://docs.oracle.com/javase/8/docs/api/java/io/BufferedInputStream.html#read-byte:A-int-int-) makes a promise that looks compelling at first:

>  As an additional convenience, it attempts to read as many bytes as possible by repeatedly invoking the read method of the underlying stream.

Seems to be exactly what we want: If a message is 200 bytes long, we want to block until we got 200 bytes in our buffer.
Sadly, `BufferedInputStream` cannot completely satisfy this requirement since it stops reading when

> The available method of the underlying stream returns zero, indicating that further input requests would block. 

This seemed to have happend, when pumping data in at a fairly high frequency. Essentially a race condition, where the underlying stream normally has data available, in every loop of the `BufferedInputStream`. Just sometimes it cannot keep up causing `BufferedInputStream.read` to return while having only read 100 bytes for example.

Of course you can then get the returned number of bytes that was actually read, and create a while loop yourself - but that's not pretty...
Luckily we already have Protobuf as a dependency, which provides the [`CodedInputStream`](https://developers.google.com/protocol-buffers/docs/reference/java/com/google/protobuf/CodedInputStream).
The reads on this class guarantee to always read the exact number of bytes specified, or `throw` upon EOF. This seems to be very appropriate in this case. It is also recommended in the protobuf docs for [streaming multiple messages](https://developers.google.com/protocol-buffers/docs/techniques#streaming).

ItelliJ IDEA, now gives a warning, since the `while(true)` loop can only be terminated by an exception.
But exception handling, and maybe also an option for graceful shutdown are subject for future development imo.
