### PR TITLE
Detecting end of stream

### DIFF
--- a/src/main/java/com/github/jtendermint/jabci/socket/TSocket.java
+++ b/src/main/java/com/github/jtendermint/jabci/socket/TSocket.java
@@ -177,7 +177,7 @@ public class TSocket extends ASocket {
             try {
                 inputStream = CodedInputStream.newInstance(socket.getInputStream());
                 outputStream = new BufferedOutputStream(socket.getOutputStream());
-                while (!isInterrupted() && !socket.isClosed()) {
+                while (!isInterrupted() && !inputStream.isAtEnd()) {
                     HANDLER_LOG.debug("start reading");
 
                     // Each Message is prefixed by a header from the gitrepos.com/tendermint/go-wire protocol.


### PR DESCRIPTION
This seems to solve issue #21 but I'm not exactly sure why. The abci-cli closes or otherwise indicates EOF on it's socket after each command. The jabci TSocket does not detect this unless we use !inputStream.isAtEnd() instead of !socket.isClosed(). I'm not sure why this is.