### PR TITLE
Fixed bug in reporting app data 'hash' on commit

### DIFF
--- a/src/main/java/com/github/jtendermint/jabci/JavaCounter.java
+++ b/src/main/java/com/github/jtendermint/jabci/JavaCounter.java
@@ -132,8 +132,9 @@ public final class JavaCounter implements IDeliverTx, ICheckTx, ICommit, IQuery 
         if (txCount == 0) {
             return ResponseCommit.newBuilder().setCode(CodeType.OK).build();
         } else {
-            ByteBuffer buf = ByteBuffer.allocate(Integer.SIZE);
+            ByteBuffer buf = ByteBuffer.allocate(Integer.BYTES);
             buf.putInt(txCount);
+            buf.rewind();
             return ResponseCommit.newBuilder().setCode(CodeType.OK).setData(ByteString.copyFrom(buf)).build();
         }
     }


### PR DESCRIPTION
We allocate 4 bytes not 32. `rewind()` is required because `copyFrom` copies from current position in ByteBuffer to end of ByteBuffer. Current position points to the end of the last 'put' so we rewind to point to the beginning.